### PR TITLE
tidy: non mutated variables to use let

### DIFF
--- a/Sources/MolecularRenderer/MRAccelBuilder+Build.swift
+++ b/Sources/MolecularRenderer/MRAccelBuilder+Build.swift
@@ -98,8 +98,8 @@ func denseGridStatistics(
             cells4[0] * cells4[1] * cells4[2])
           references += Double(products0.sum())
           
-          var minCoords = simd_min(vector.lowHalf, vector.highHalf)
-          var maxCoords = simd_max(vector.lowHalf, vector.highHalf)
+          let minCoords = simd_min(vector.lowHalf, vector.highHalf)
+          let maxCoords = simd_max(vector.lowHalf, vector.highHalf)
           minCoordinatesVector = simd_min(minCoordinatesVector, minCoords)
           maxCoordinatesVector = simd_max(maxCoordinatesVector, maxCoords)
         }
@@ -171,7 +171,7 @@ extension MRAccelBuilder {
     let voxel_width_numer: Float = 4
     let voxel_width_denom: Float = (sceneSize == .small) ? 16 : 8
     let statisticsStart = CACurrentMediaTime()
-    var statistics = denseGridStatistics(
+    let statistics = denseGridStatistics(
       atoms: atoms,
       styles: styles,
       voxel_width_numer: voxel_width_numer,

--- a/Sources/MolecularRenderer/MRSimulation.swift
+++ b/Sources/MolecularRenderer/MRSimulation.swift
@@ -195,7 +195,7 @@ public class MRSimulation {
     }
     
     // Decoding will use a similar method, which generates words upon each call.
-    var header = ExpandingBuffer(device: renderer.device)
+    let header = ExpandingBuffer(device: renderer.device)
     var headerWords: [UInt64] = []
     func appendHeaderWords() {
       header.reserve(headerWords.count * 8)
@@ -269,7 +269,7 @@ public class MRSimulation {
       
       // compressed staticMetadata count, staticMetadata
       if staticMetadata.count > 0 {
-        var dst = UnsafeMutablePointer<UInt8>
+        let dst = UnsafeMutablePointer<UInt8>
           .allocate(capacity: staticMetadata.count)
         defer { dst.deallocate() }
         
@@ -386,7 +386,7 @@ public class MRSimulation {
       precondition(compressedCount > 0)
       
       checkCapacity(compressedCount)
-      var dst = UnsafeMutablePointer<UInt8>
+      let dst = UnsafeMutablePointer<UInt8>
         .allocate(capacity: staticMetadataCount)
       defer { dst.deallocate() }
       


### PR DESCRIPTION
checked out this project and ran `swift build`, which gave me a collection of warnings, this PR addresses the warnings

example warning: 

```swift
Sources/MolecularRenderer/MRAccelBuilder+Build.swift:102:15: warning: variable 'maxCoords' was never mutated; consider changing to 'let' constant
          var maxCoords = simd_max(vector.lowHalf, vector.highHalf)
          ~~~ ^
          let
```

---
p.s. 
There were a couple other warnings for unused variables (which seemed to be assigned from pure functions) as shown below. I cannot reproduce these on sequential `swift build` invocations, but have intentionally **not** addressed these in this PR, maybe there could be a proper fix for those more robustly long term?

(Just trying to build/run this project!, very much a noob to swift/xcodeproj)

Examples of other warnings: 

```swift
Sources/MolecularRenderer/MRAccelBuilder.swift:167:9: warning: initialization of immutable value 'atomBufferSize' was never used; consider replacing with assignment to '_' or removing it
    let atomBufferSize = atoms.count * atomSize
    ~~~~^~~~~~~~~~~~~~
    _
```
and 
```
Sources/MolecularRenderer/MRAccelBuilder+Build.swift:144:9: warning: initialization of immutable value 'cellSpan' was never used; consider replacing with assignment to '_' or removing it
    let cellSpan = 1 + ceil(
    ~~~~^~~~~~~~
```